### PR TITLE
Call to `yaffs_tags_marshall_read` made through pointer in device struct

### DIFF
--- a/core/yaffs_tagsmarshall.c
+++ b/core/yaffs_tagsmarshall.c
@@ -159,7 +159,7 @@ static int yaffs_tags_marshall_query_block(struct yaffs_dev *dev, int block_no,
 	} else {
 		struct yaffs_ext_tags t;
 
-		yaffs_tags_marshall_read(dev,
+		dev->tagger.read_chunk_tags_fn(dev,
 				    block_no * dev->param.chunks_per_block,
 				    NULL, &t);
 


### PR DESCRIPTION
I think it's more correct not to call `yaffs_tags_marshall_read` in `yaffs_tags_marshall_query_block` directly, but to use a pointer in the device structure for this. By default pointer points to `yaffs_tags_marshall_read`, but this can be overridden.