### PR TITLE
Increase scope of yaffs gross lock to avoid race and kernel panic:

### DIFF
--- a/linux/yaffs_vfs_multi.c
+++ b/linux/yaffs_vfs_multi.c
@@ -1657,19 +1657,18 @@ static int yaffs_rename(struct inode *old_dir, struct dentry *old_dentry,
 					   yaffs_inode_to_obj(new_dir),
 					   new_dentry->d_name.name);
 	}
-	yaffs_gross_unlock(dev);
 
 	if (ret_val == YAFFS_OK) {
 		if (target)
 			inode_dec_link_count(new_dentry->d_inode);
-
+		yaffs_gross_unlock(dev);
 		update_dir_time(old_dir);
 		if (old_dir != new_dir)
 			update_dir_time(new_dir);
 		return 0;
-	} else {
-		return -ENOTEMPTY;
 	}
+	yaffs_gross_unlock(dev);
+	return -ENOTEMPTY;
 }
 
 

--- a/linux/yaffs_vfs_single.c
+++ b/linux/yaffs_vfs_single.c
@@ -489,19 +489,18 @@ static int yaffs_rename(struct inode *old_dir, struct dentry *old_dentry,
 					   yaffs_inode_to_obj(new_dir),
 					   new_dentry->d_name.name);
 	}
-	yaffs_gross_unlock(dev);
 
 	if (ret_val == YAFFS_OK) {
 		if (target)
 			inode_dec_link_count(new_dentry->d_inode);
-
+		yaffs_gross_unlock(dev);
 		update_dir_time(old_dir);
 		if (old_dir != new_dir)
 			update_dir_time(new_dir);
 		return 0;
-	} else {
-		return -ENOTEMPTY;
 	}
+	yaffs_gross_unlock(dev);
+	return -ENOTEMPTY;
 }
 
 static int yaffs_setattr(struct dentry *dentry, struct iattr *attr)


### PR DESCRIPTION
```
Unable to handle kernel NULL pointer dereference at virtual address 0000002c
...

drop_nlink+0x4/0x3c
yaffs_rename+0xd9/0x144
vfs_rename2+0x2d9/0x63c
sys_renameat2+0x21d/0x332
sys_renameat+0xb/0xe

... because new_dentry->d_inode is NULL due to the inode being deleted
and the pointer nulled out in a different thread.
```