### PR TITLE
Fix /proc/yaffs state dumping when YAFFS_NEW_PROCFS is defined

### DIFF
--- a/linux/yaffs_vfs_multi.c
+++ b/linux/yaffs_vfs_multi.c
@@ -3723,13 +3723,16 @@ static struct file_system_to_install fs_to_install[] = {
 #ifdef YAFFS_NEW_PROCFS
 static int yaffs_proc_show(struct seq_file *m, void *v)
 {
-	/* FIXME: Unify in a better way? */
-	char buffer[512];
 	char *start;
-	int len;
+	int step, len;
+	char buffer[1024];
 
-	len = yaffs_proc_read(buffer, &start, 0, sizeof(buffer), NULL, NULL);
-	seq_puts(m, buffer);
+	for (step = 0; ; step++) {
+		len = yaffs_proc_read(buffer, &start, step, sizeof(buffer), NULL, NULL);
+		if (len <= 0)
+			break;
+		seq_puts(m, buffer);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Some of the state of Yaffs mounts can be determined by reading the /proc/yaffs entry:
  - https://yaffs.net/documents/yaffs-tuning

That was not working when YAFFS_NEW_PROCFS is defined because in order to reuse the same routine for older proc APIs and newer ones, the function was only being called with a fixed step parameter instead of iterating into it while it still has data. Current version reuses the original function but iterates on it.