### PR TITLE
Direct: set `d_type` field in yaffsfs_readdir_no_lock()

### DIFF
--- a/direct/yaffsfs.c
+++ b/direct/yaffsfs.c
@@ -3601,6 +3601,7 @@ struct yaffs_dirent *yaffsfs_readdir_no_lock(yaffs_DIR * dirp)
 				yaffs_strcpy(dsc->de.d_name, _Y("zz"));
 			}
 			dsc->de.d_reclen = sizeof(struct yaffs_dirent);
+			dsc->de.d_type = yaffs_get_obj_type(dsc->nextReturn);
 			retVal = &dsc->de;
 			yaffsfs_DirAdvance(dsc);
 		} else


### PR DESCRIPTION
Using `yaffs_readdir` in `direct` code `d_type` field was always bad while traversing directories.
Look's like it just wasn't assigned in `yaffsfs_readdir_no_lock()`.