### PR TITLE
utils/Makefile: fix symbolic links

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -45,7 +45,7 @@ ALL_LINKS = $(BASE_LINKS) $(DIRECT_LINKS)
 all: mkyaffsimage mkyaffs2image
 
 $(BASE_LINKS):
-	ln -s ../$@ $@
+	ln -s ../core/$@ $@
 
 $(DIRECT_LINKS):
 	ln -s ../direct/$@ $@


### PR DESCRIPTION
Create correct symlinks to fix the following error:

mkyaffsimage.c:29:10: fatal error: yaffs_ecc.h: No such file or directory
   29 | #include "yaffs_ecc.h"
      |          ^~~~~~~~~~~~~