### PR TITLE
Fix race yaffs_flush_inodes against iput (for vfs_multi)

### DIFF
--- a/linux/yaffs_vfs_multi.c
+++ b/linux/yaffs_vfs_multi.c
@@ -2352,22 +2352,40 @@ static void yaffs_bg_stop(struct yaffs_dev *dev)
 }
 #endif
 
-
 static void yaffs_flush_inodes(struct super_block *sb)
 {
 	struct inode *iptr;
 	struct yaffs_obj *obj;
-
+	struct yaffs_dev *dev = yaffs_super_to_dev(sb);
+	
+	spin_lock(&sb->s_inode_list_lock);
 	list_for_each_entry(iptr, &sb->s_inodes, i_sb_list) {
+		spin_lock(&iptr->i_lock);
+		if (iptr->i_state & (I_FREEING|I_WILL_FREE|I_NEW)) {
+			spin_unlock(&iptr->i_lock);
+			continue;
+		}
+		
+		__iget(iptr);
+		spin_unlock(&iptr->i_lock);
+		spin_unlock(&sb->s_inode_list_lock);
+		
 		obj = yaffs_inode_to_obj(iptr);
 		if (obj) {
 			yaffs_trace(YAFFS_TRACE_OS,
-				"flushing obj %d",
-				obj->obj_id);
+			    "flushing obj %d", obj->obj_id);
 			yaffs_flush_file(obj, 1, 0, 0);
 		}
+		
+		yaffs_gross_unlock(dev);
+		iput(iptr);
+		yaffs_gross_lock(dev);
+		
+		spin_lock(&sb->s_inode_list_lock);
 	}
+	spin_unlock(&sb->s_inode_list_lock);
 }
+
 
 static void yaffs_flush_super(struct super_block *sb, int do_checkpoint)
 {

--- a/linux/yaffs_vfs_single.c
+++ b/linux/yaffs_vfs_single.c
@@ -1492,14 +1492,14 @@ static void yaffs_flush_inodes(struct super_block *sb)
 
 	spin_lock(&sb->s_inode_list_lock);
 	list_for_each_entry(iptr, &sb->s_inodes, i_sb_list) {
-		spin_lock(&inode->i_lock);
+		spin_lock(&iptr->i_lock);
 		if (iptr->i_state & (I_FREEING|I_WILL_FREE|I_NEW)) {
 			spin_unlock(&inode->i_lock);
 			continue;
 		}
 
 		__iget(iptr);
-		spin_unlock(&inode->i_lock);
+		spin_unlock(&iptr->i_lock);
 		spin_unlock(&sb->s_inode_list_lock);
 
 		obj = yaffs_inode_to_obj(iptr);


### PR DESCRIPTION
Fix compile error in yaffs_vfs_single: inode should be iptr.

Merge fix https://github.com/Aleph-One-Ltd/yaffs2/commit/b4ce1bb1b46accb1619dc07164ef6945feded9db to yaffs_vfs_multi